### PR TITLE
BUG Fix: Vector2D operators

### DIFF
--- a/BirchEngine/Src/Vector2D.cpp
+++ b/BirchEngine/Src/Vector2D.cpp
@@ -44,24 +44,36 @@ Vector2D& Vector2D::Divide(const Vector2D& vec)
 	return *this;
 }
 
-Vector2D& operator+(Vector2D& v1, const Vector2D& v2)
+Vector2D Vector2D::operator+ ( const Vector2D& vec )
 {
-	return v1.Add(v2);
+	Vector2D result;
+	result.x = this->x + vec.x;
+	result.y = this->y + vec.y;
+	return result;
 }
 
-Vector2D& operator-(Vector2D& v1, const Vector2D& v2)
+Vector2D Vector2D::operator- ( const Vector2D& vec )
 {
-	return v1.Subtract(v2);
+	Vector2D result;
+	result.x = this->x - vec.x;
+	result.y = this->y - vec.y;
+	return result;
 }
 
-Vector2D& operator*(Vector2D& v1, const Vector2D& v2)
+Vector2D Vector2D::operator* ( const Vector2D& vec )
 {
-	return v1.Multiply(v2);
+	Vector2D result;
+	result.x = this->x * vec.x;
+	result.y = this->y * vec.y;
+	return result;
 }
 
-Vector2D& operator/(Vector2D& v1, const Vector2D& v2)
+Vector2D Vector2D::operator/ ( const Vector2D& vec )
 {
-	return v1.Divide(v2);
+	Vector2D result;
+	result.x = this->x / vec.x;
+	result.y = this->y / vec.y;
+	return result;
 }
 
 Vector2D& Vector2D::operator+=(const Vector2D& vec)

--- a/BirchEngine/Src/Vector2D.h
+++ b/BirchEngine/Src/Vector2D.h
@@ -15,10 +15,10 @@ public:
 	Vector2D& Multiply(const Vector2D& vec);
 	Vector2D& Divide(const Vector2D& vec);
 
-	friend Vector2D& operator+(Vector2D& v1, const Vector2D& v2);
-	friend Vector2D& operator-(Vector2D& v1, const Vector2D& v2);
-	friend Vector2D& operator*(Vector2D& v1, const Vector2D& v2);
-	friend Vector2D& operator/(Vector2D& v1, const Vector2D& v2);
+	Vector2D operator+ ( const Vector2D& vec );
+	Vector2D operator- ( const Vector2D& vec );
+	Vector2D operator* ( const Vector2D& vec );
+	Vector2D operator/ ( const Vector2D& vec );
 
 	Vector2D& operator+=(const Vector2D& vec);
 	Vector2D& operator-=(const Vector2D& vec);


### PR DESCRIPTION
Hello,

Since I appreciate your Youtube series and really like to make games I wanted to contribute to your game engine. I found 4 bugs. Also this is my first pull request ever.

The "Vector2D& operator+(Vector2D& v1, const Vector2D& v2)"
should not modify v1, but should only return the result of v1+v2
Similar for Vector2D operator-, orerator* and operator/

The Vector2D operator-=, orerator*= and operator/= are correct.

Thanks again